### PR TITLE
諸々settings.yamlに切り出し

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 token.yaml
+settings.yaml
 tmp
 gcp-key.json
 

--- a/gozyosen_slot/gozyosen_slot.py
+++ b/gozyosen_slot/gozyosen_slot.py
@@ -6,7 +6,7 @@ import yaml
 # //////////////////////////////////////////////////////////////////////
 # constant definition
 
-slot_settings = yaml.load(open('token.yaml').read(), Loader=yaml.SafeLoader)['gozyosen_slot']
+slot_settings = yaml.load(open('settings.yaml').read(), Loader=yaml.SafeLoader)['gozyosen_slot']
 GOJO_EMOJI = slot_settings['emoji']['gojo']
 MARKS = slot_settings['emoji']['slot_marks_gojo']
 MARKS_SLOT = slot_settings['emoji']['slot_marks']

--- a/gozyosen_slot/gozyosen_slot.py
+++ b/gozyosen_slot/gozyosen_slot.py
@@ -1,13 +1,16 @@
 from discord.ext import commands
 import random
 import asyncio
+import yaml
 
 # //////////////////////////////////////////////////////////////////////
 # constant definition
-GOJO_EMOJI = "<:gojo:836228626957074453>"
-MARKS = ["<:emoji_48:986146778279718912>", "<:gojo:836228626957074453>"]
-MARKS_SLOT = ["<:emoji_47:981211597093621771>", "<:emoji_46:981211581587279883>", "<:dayu_coume:929077269568294934>", "<:koume_another:937032580182728774>", "<:fushigidane:838103311734669393>", "<:seikintv:885186342907170906>", "<:chiikawa_bakemon:929075742296399954>", "<:emoji_48:986146778279718912>", "<:gojo:836228626957074453>"]
-MARKS_WACCA = ["<:su:986850329998028831>", "<:teki:986850365951578115>", "<:da:986850393357172757>", "<:ne:986850420439810078>"]
+
+slot_settings = yaml.load(open('token.yaml').read(), Loader=yaml.SafeLoader)['gozyosen_slot']
+GOJO_EMOJI = slot_settings['emoji']['gojo']
+MARKS = slot_settings['emoji']['slot_marks_gojo']
+MARKS_SLOT = slot_settings['emoji']['slot_marks']
+MARKS_WACCA = slot_settings['emoji']['wacca']
 
 # //////////////////////////////////////////////////////////////////////
 # commands 

--- a/settings-template.yaml
+++ b/settings-template.yaml
@@ -1,3 +1,10 @@
 text_to_speech:
-  gcp_credential_path: 'gcp-key.json'
-  enable_channels: [766330592441794642]
+  gcp_credential_path: 'hoge.json'
+  enable_channels: []
+
+gozyosen_slot:
+  emoji:
+    gojo: ""
+    slot_marks_gojo: []
+    slot_marks: []
+    wacca: []

--- a/settings-template.yaml
+++ b/settings-template.yaml
@@ -1,0 +1,3 @@
+text_to_speech:
+  gcp_credential_path: 'gcp-key.json'
+  enable_channels: [766330592441794642]

--- a/text_to_speech/text_to_speech.py
+++ b/text_to_speech/text_to_speech.py
@@ -7,17 +7,20 @@ from google.cloud import texttospeech
 
 os.environ['GOOGLE_APPLICATION_CREDENTIALS'] = 'gcp-key.json'
 tts_client = texttospeech.TextToSpeechClient()
-ENABLE_CHANNELS = [766330592441794642] # todo settings.json的なのに出す
 
 class TextToSpeech(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
         self.voice_client = None;
 
+        settings_info = yaml.load(open('settings.yaml').read(), Loader=yaml.SafeLoader)['text_to_speech']
+        os.environ['GOOGLE_APPLICATION_CREDENTIALS'] = settings_info['gcp_credential_path']
+        self.ENABLE_CHANNELS = settings_info['enable_channels']
+
     @commands.Cog.listener(name='on_message')
     async def read_message(self, message):
         # 指定されたチャンネルのメッセージのみ再生
-        if message.channel.id not in ENABLE_CHANNELS:
+        if message.channel.id not in self.ENABLE_CHANNELS:
             return
 
         if self.voice_client is None and message.author.voice is not None:

--- a/text_to_speech/text_to_speech.py
+++ b/text_to_speech/text_to_speech.py
@@ -3,8 +3,11 @@ from discord.channel import VoiceChannel
 import discord
 import asyncio
 import os
+import yaml
 from google.cloud import texttospeech
 
+settings_info = yaml.load(open('settings.yaml').read(), Loader=yaml.SafeLoader)['text_to_speech']
+os.environ['GOOGLE_APPLICATION_CREDENTIALS'] = settings_info['gcp_credential_path']
 tts_client = texttospeech.TextToSpeechClient()
 
 class TextToSpeech(commands.Cog):
@@ -12,8 +15,6 @@ class TextToSpeech(commands.Cog):
         self.bot = bot
         self.voice_client = None;
 
-        settings_info = yaml.load(open('settings.yaml').read(), Loader=yaml.SafeLoader)['text_to_speech']
-        os.environ['GOOGLE_APPLICATION_CREDENTIALS'] = settings_info['gcp_credential_path']
         self.ENABLE_CHANNELS = settings_info['enable_channels']
 
     @commands.Cog.listener(name='on_message')

--- a/text_to_speech/text_to_speech.py
+++ b/text_to_speech/text_to_speech.py
@@ -9,18 +9,17 @@ from google.cloud import texttospeech
 settings_info = yaml.load(open('settings.yaml').read(), Loader=yaml.SafeLoader)['text_to_speech']
 os.environ['GOOGLE_APPLICATION_CREDENTIALS'] = settings_info['gcp_credential_path']
 tts_client = texttospeech.TextToSpeechClient()
+ENABLE_CHANNELS = settings_info['enable_channels']
 
 class TextToSpeech(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
         self.voice_client = None;
 
-        self.ENABLE_CHANNELS = settings_info['enable_channels']
-
     @commands.Cog.listener(name='on_message')
     async def read_message(self, message):
         # 指定されたチャンネルのメッセージのみ再生
-        if message.channel.id not in self.ENABLE_CHANNELS:
+        if message.channel.id not in ENABLE_CHANNELS:
             return
 
         if self.voice_client is None and message.author.voice is not None:

--- a/text_to_speech/text_to_speech.py
+++ b/text_to_speech/text_to_speech.py
@@ -5,7 +5,6 @@ import asyncio
 import os
 from google.cloud import texttospeech
 
-os.environ['GOOGLE_APPLICATION_CREDENTIALS'] = 'gcp-key.json'
 tts_client = texttospeech.TextToSpeechClient()
 
 class TextToSpeech(commands.Cog):


### PR DESCRIPTION
ttsとslotの定数情報をyamlに切り出し

一応templateも用意

yamlの中身は現状クソゲー部用こんな感じ

```
text_to_speech:
  gcp_credential_path: 'gcp-key.json'
  enable_channels: [990271412742782976]　

gozyosen_slot:
  emoji:
    gojo: "<:gojo:836228626957074453>"
    slot_marks_gojo: ["<:emoji_48:986146778279718912>", "<:gojo:836228626957074453>"]
    slot_marks: ["<:emoji_47:981211597093621771>", "<:emoji_46:981211581587279883>", "<:dayu_coume:929077269568294934>", "<:koume_another:937032580182728774>", "<:fushigidane:838103311734669393>", "<:seikintv:885186342907170906>", "<:chiikawa_bakemon:929075742296399954>", "<:emoji_48:986146778279718912>", "<:gojo:836228626957074453>"]
    wacca: ["<:su:986850329998028831>", "<:teki:986850365951578115>", "<:da:986850393357172757>", "<:ne:986850420439810078>"]
```